### PR TITLE
Try opening PR after publishing manifest.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,47 +2,71 @@ name: Reusable deployment workflow
 on:
   workflow_call:
     inputs:
-      # Controls where in the `socotra-release` repo to write the application
-      # manifest.
-      #
-      # Example: "frontend-v2", "loadassets2", etc.
       app_name:
+        description: >
+          The name of the application to deploy.
+
+          Controls where in the `socotra-release` repo to write the application
+          manifest.
+
+          Example: "frontend-v2", "loadassets2", etc.
         required: true
         type: string
-      # Controls which overlay to use for building the manifest, and where in
-      # the `socotra-release` repo to write the rendered manifest.
-      #
-      # This can be a space-separated list of multiple environments.
-      #
-      # Examples:
-      #   * "develop"
-      #   * "staging"
-      #   * "axa-production moo-production toni-production ..."
+
       environment:
+        description: >
+          A space-separated list of environment(s) to which the application
+          shall be deployed.
+
+          Controls which overlay to use for building the manifest, and where in
+          the `socotra-release` repo to write the rendered manifest.
+
+          This can be a space-separated list of multiple environments.
+
+          Examples:
+            * "develop"
+            * "staging"
+            * "axa-production moo-production toni-production ..."
         required: true
         type: string
-      # The generic name of the container image specified in this application's
-      # base manifests.
-      #
-      # Example: "socotra/frontend-v2", "socotra/loadassets2", etc.
+
       image_name:
+        description: >
+          The generic name of the container image specified in the application's
+          base manifests.
+
+          Examples:
+            * "socotra/frontend-v2"
+            * "socotra/loadassets2"
         required: true
         type: string
-      # Which container image tag to use for the above image.
+
       image_tag:
+        description: The container image tag to use for the above image.
         required: true
         type: string
-      # Which branch of the `soctora-release` repo in which to write the new
-      # manifest.
+
       branch:
+        description: >
+          The branch of the `soctora-release` repo in which to write the new
+          manifest(s).
+
+          By default, this is 'master', so the new manifest(s) will get picked
+          up by our deployment system. Keep in mind, though, that production
+          environments' applications won't auto-sync, but require further
+          approval within ArgoCD.
+
+          If this parameter is anything but 'master', then the manifest(s) will
+          be written to a new or existing branch, and a PR will be opened for
+          merging it back into the master branch.
         required: false
         type: string
         default: master
     secrets:
-      # We need a specific token to check out the socotra-release repo, since
-      # the default ${{ secrets.GITHUB_TOKEN }} does not have the appropriate
-      # permissions.
       our_github_token:
+        description: >
+          We need a specific token to check out the socotra-release repo, since
+          the default GITHUB_TOKEN does not have the appropriate permissions.
         required: true
 
 jobs:
@@ -54,18 +78,13 @@ jobs:
       with:
         fetch-depth: 0
     - name: Checkout socotra-release
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: socotra/socotra-release
         token: ${{ secrets.our_github_token }}
         path: /home/runner/work/${{ inputs.app_name }}/${{ inputs.app_name }}/socotra-release
         ref: master
         fetch-depth: 0
-    - name: Create socotra-release branch
-      run: |
-        [[ "${{ inputs.branch }}" == "master" ]] && exit 0
-        cd /home/runner/work/${{ inputs.app_name }}/${{ inputs.app_name }}/socotra-release
-        git checkout ${{ inputs.branch }} || git checkout -b ${{ inputs.branch }}
     - name: Setup
       run: |
         set -e
@@ -124,7 +143,32 @@ jobs:
         git config --global user.email devops@socotra.com
         git config --global push.default current
         git add .
+        # if non-'master' branch, let the peter-evans/create-pull-request action
+        # manage commit & push
+        [[ "${{ inputs.branch }}" != "master" ]] && exit 0
         git commit -a -m "Deploy ${{ inputs.app_name }} with tag ${{ inputs.image_tag }}."
         while ! git push; do
           git pull --rebase
         done
+
+    - name: Create Pull Request
+      if: inputs.branch != 'master'
+      uses: peter-evans/create-pull-request@v4
+      with:
+        path: /home/runner/work/${{ inputs.app_name }}/${{ inputs.app_name }}/socotra-release
+        token: ${{ secrets.our_github_token }}
+        branch: ${{ inputs.branch }}
+        delete-branch: true
+        base: master
+        title: "Deploy ${{ inputs.app_name }} with tag ${{ inputs.image_tag }}"
+        commit-message: |
+          Deploy ${{ inputs.app_name }} with tag ${{ inputs.image_tag }}
+
+          Generated by:
+          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        author: "Socotra DevOps <devops@socotra.com>"
+        team-reviewers: devops
+        body: |2
+           | App | Tag | Run URL |
+           | --- | --- | --- |
+           | ${{ inputs.app_name }} | ${{ inputs.image_tag }} | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |


### PR DESCRIPTION
Extend our deployment workflow to create a PR against the socotra-release repository, when appropriate.

* The PR includes the application name, container tag, and a link back to the Github Actions run which generated the PR.
* Some minor tweaks to the logic so that the requirements of the [`peter-evans/create-pull-request@v4`](https://github.com/marketplace/actions/create-pull-request) action are met.
* Also, I moved the comments for the input parameters & secrets to `description:` fields.