### PR TITLE
Fix deprecated GitHub Actions syntax

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -74,11 +74,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Checkout socotra-release
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: socotra/socotra-release
         token: ${{ secrets.our_github_token }}

--- a/.github/workflows/docker-build-push-with-arm64.yaml
+++ b/.github/workflows/docker-build-push-with-arm64.yaml
@@ -69,7 +69,7 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Download an artifact

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -67,7 +67,7 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Download an artifact

--- a/.github/workflows/update-gradle-deps.yaml
+++ b/.github/workflows/update-gradle-deps.yaml
@@ -57,7 +57,7 @@ jobs:
         repo: ${{ fromJSON(inputs.repos) }}
     steps:
     - name: Checkout service repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: socotra/${{ matrix.repo }}
         token: ${{ secrets.our_github_token }}


### PR DESCRIPTION
This PR updates deprecated GitHub Actions syntax:
- Replaces ::set-output with GITHUB_OUTPUT
- Upgrades common actions to Node.js 24 compatible versions