### PR TITLE
chore(ci): fix deprecated GitHub Actions syntax

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -74,11 +74,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Checkout socotra-release
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: socotra/socotra-release
         token: ${{ secrets.our_github_token }}

--- a/.github/workflows/docker-build-push-with-arm64.yaml
+++ b/.github/workflows/docker-build-push-with-arm64.yaml
@@ -69,7 +69,7 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Download an artifact
@@ -96,8 +96,8 @@ jobs:
         branch_prefix=$(echo ${{ github.ref_name }} | sed 's/\//-/g')
         commit_short=$(echo ${{ github.sha }} | cut -b 1-8)
         unique_tag="${branch_prefix}-${{ github.run_number }}-${{ github.run_attempt }}-${commit_short}"
-        echo "::set-output name=unique::$unique_tag"
-        echo "::set-output name=sanitized_branch::$branch_prefix"
+        echo "unique=$unique_tag" >> "$GITHUB_OUTPUT"
+        echo "sanitized_branch=$branch_prefix" >> "$GITHUB_OUTPUT"
     - name: Tag and push container image
       env:
         ECR_REGISTRY: 936926373655.dkr.ecr.us-west-2.amazonaws.com

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -67,7 +67,7 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Download an artifact
@@ -91,8 +91,8 @@ jobs:
         branch_prefix=$(echo ${{ github.ref_name }} | sed 's/\//-/g')
         commit_short=$(echo ${{ github.sha }} | cut -b 1-8)
         unique_tag="${branch_prefix}-${{ github.run_number }}-${{ github.run_attempt }}-${commit_short}"
-        echo "::set-output name=unique::$unique_tag"
-        echo "::set-output name=sanitized_branch::$branch_prefix"
+        echo "unique=$unique_tag" >> "$GITHUB_OUTPUT"
+        echo "sanitized_branch=$branch_prefix" >> "$GITHUB_OUTPUT"
     - name: Tag and push container image
       env:
         ECR_REGISTRY: 936926373655.dkr.ecr.us-west-2.amazonaws.com

--- a/.github/workflows/update-gradle-deps.yaml
+++ b/.github/workflows/update-gradle-deps.yaml
@@ -57,7 +57,7 @@ jobs:
         repo: ${{ fromJSON(inputs.repos) }}
     steps:
     - name: Checkout service repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: socotra/${{ matrix.repo }}
         token: ${{ secrets.our_github_token }}


### PR DESCRIPTION
Automated update for CI deprecations:

- [`::set-output` / `::save-state`](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) → environment files
- [`actions/checkout` v4 and older on Node 20 runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) → `actions/checkout@v5`

Please review: complex `set-output` values (multiline, special chars) may need a manual tweak.
